### PR TITLE
Feature/convert negative numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ This will convert the alphanumeric string '15   k' into an integer like 15000 (i
 |`numify("1K")     `| 1000|
 |`numify("1k")     `| 1000|
 |`numify("1   K")  `| 1000|
-|`numify("1.5K)    `| 1500|
-|`numify("1M)      `| 1000000|
-|`numify("1.5m)    `| 1500000|
-|`numify("1B)      `| 1000000000|
-|`numify("1.5b)    `| 1500000000|
-|`numify("1T)      `| 1000000000000|
+|`numify("1.5K")   `| 1500|
+|`numify("1M")     `| 1000000|
+|`numify("1.5m")   `| 1500000|
+|`numify("1B")     `| 1000000000|
+|`numify("1.5b")   `| 1500000000|
+|`numify("1T")     `| 1000000000000|
+|`numify("-1M")    `| -1000000|
 
 
 ## Testing
 `$ python numify/numify_test.py`
-

--- a/numify/__init__.py
+++ b/numify/__init__.py
@@ -1,4 +1,4 @@
 # __init__.py
 
 # Version of numify alphanumeric converter
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/numify/numify.py
+++ b/numify/numify.py
@@ -10,7 +10,7 @@ def numify(alphanum):
         num (int, float): The equivalent of `alphanum` in integer or float.
         
     Raises:
-        ValueError: Raised if alphanum does not match the pattern `^([0-9]*)(\s)?([kKmMbB])$`
+        ValueError: Raised if alphanum does not match the pattern `^(-?[0-9]*)(\s)?([kKmMbB])$`
         
     Notes:
         print(numify('2k')) // 2000
@@ -20,7 +20,7 @@ def numify(alphanum):
         A more comprehensive usage example can be found here https://jaboadley.netlify.app 
     """
     # Check if alphanum format is valid
-    pattern =  '^([0-9.]*)(\s)*([kKmMbBtT])$'
+    pattern =  '^(-?[0-9.]*)(\s)*([kKmMbBtT])$'
     match =  re.search(pattern, alphanum)
     if match is None:
 	    raise ValueError("Invalid Input: correct format is 1k, 1K, 1 k, 1 K.")

--- a/numify/numify_test.py
+++ b/numify/numify_test.py
@@ -4,18 +4,18 @@ import unittest
 # ** Tests**
 class TestNumify(unittest.TestCase):
 
-    # Test if middle spaces are ignored 
+    # Test if middle spaces are ignored
     def test_middle_space(self):
         testcase = "2   k"
         expected = 2000
         self.assertEqual(numify(testcase), expected)
-    
+
     # Test if the trailing alphabet if case insensitive
     def test_capitals(self):
         testcase = "30K"
         expected = 30000
         self.assertEqual(numify(testcase), expected)
-    
+
     # Test if alphanumeric characters containing floats is handled correctly
     def test_float(self):
         self.assertEqual(numify("23.4k"), 23400)
@@ -23,5 +23,8 @@ class TestNumify(unittest.TestCase):
     # Test if alphanumeric characters raises errors
     def test_not_alphanum(self):
         self.assertRaises(ValueError, numify, "32")
+
+    def test_negative_alphanum_value(self):
+        self.assertEqual(numify("-33.65M"), -33650000)
 
 unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="numify",
-    version="1.0.1",
+    version="1.1.0",
     description="Convert alphanumeric characters to integers i.e 1k to 1000",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
`numify` will raise and exception if you pass it an alphanumeric string with a negative number.

```python
numify("-33.65M")
# raises `ValueError("Invalid Input: correct format is 1k, 1K, 1 k, 1 K.")`
```

I added a slight variation to the regex pattern to allow negative numbers. No other logic changes were needed to make this work.